### PR TITLE
[18.0][IMP] dotfiles: Use pyproject.toml instead of setup.py

### DIFF
--- a/.copier-answers.yml
+++ b/.copier-answers.yml
@@ -22,6 +22,6 @@ repo_description: ''
 repo_name: SMI OCA
 repo_slug: smi-oca
 repo_website: ''
-use_pyproject_toml: false
+use_pyproject_toml: true
 use_ruff: true
 

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -38,6 +38,10 @@ repos:
         entry: found a en.po file
         language: fail
         files: '[a-zA-Z0-9_]*/i18n/en\.po$'
+  - repo: https://github.com/sbidoul/whool
+    rev: v1.2
+    hooks:
+      - id: whool-init
   - repo: https://github.com/oca/maintainer-tools
     rev: bf9ecb9938b6a5deca0ff3d870fbd3f33341fded
     hooks:
@@ -54,6 +58,7 @@ repos:
       #     - --if-source-changed
       #     - --keep-source-digest
       #     - --convert-fragments-to-markdown
+      - id: oca-gen-external-dependencies
   - repo: https://github.com/OCA/odoo-pre-commit-hooks
     rev: v0.0.33
     hooks:
@@ -113,16 +118,6 @@ repos:
       - id: check-xml
       - id: mixed-line-ending
         args: ["--fix=lf"]
-  - repo: https://github.com/acsone/setuptools-odoo
-    rev: 3.1.8
-    hooks:
-      - id: setuptools-odoo-make-default
-      - id: setuptools-odoo-get-requirements
-        args:
-          - --output
-          - requirements.txt
-          - --header
-          - "# generated from manifests external_dependencies"
   - repo: https://github.com/astral-sh/ruff-pre-commit
     rev: v0.6.8
     hooks:


### PR DESCRIPTION
I noticed `setuptools-odoo` is supported up to 16.0.